### PR TITLE
change output to 1 decimal place

### DIFF
--- a/src/bimorph_mirror_analysis/maths.py
+++ b/src/bimorph_mirror_analysis/maths.py
@@ -87,7 +87,7 @@ pencil beam scans
         interaction_matrix_inv, desired_corrections
     )
 
-    return np.round(voltage_corrections[1:], decimals=2)  # return the voltages
+    return np.round(voltage_corrections[1:], decimals=1)  # return the voltages
 
 
 def objective_function(
@@ -232,7 +232,7 @@ pencil beam scans
         options={"maxiter": 3 * 10**5},
     )
 
-    return np.round(result.x[1:], decimals=2)  # first item is not a voltage
+    return np.round(result.x[1:], decimals=1)  # first item is not a voltage
 
 
 def check_voltages_fit_constraints(
@@ -257,7 +257,8 @@ def check_voltages_fit_constraints(
     )
 
     diffs = np.diff(voltages)
-    within_max_diff = np.all(diffs <= max_consecutive_voltage_difference)
+    # add tolerance of 0.00001 to account for floating point errors
+    within_max_diff = np.all(abs(diffs) <= max_consecutive_voltage_difference + 0.0001)
 
     # bool required as np.all returns np.bool
     return bool(within_max_and_min and within_max_diff)

--- a/tests/program_test.py
+++ b/tests/program_test.py
@@ -29,9 +29,9 @@ def test_calculate_optimal_voltages_mocked(raw_data_pivoted: pd.DataFrame):
         )
         mock_find_voltage_corrections.side_effect = find_voltage_corrections
         voltages = calculate_optimal_voltages("input_file", (-1000, 1000), 500)
-        voltages = np.round(voltages, 2)
+        voltages = np.round(voltages, 1)
         # assert correct voltages calculated
-        np.testing.assert_almost_equal(voltages, np.array([72.14, 50.98, 18.59]))
+        np.testing.assert_almost_equal(voltages, np.array([72.1, 51.0, 18.6]))
 
         # assert mock was called
         mock_read_bluesky_plan_output.assert_called()
@@ -89,9 +89,9 @@ def test_calculate_optimal_voltages(
         )
 
         # assert correct voltages calculated
-        voltages = np.round(voltages, 2)
+        voltages = np.round(voltages, 1)
         np.testing.assert_almost_equal(
-            voltages, initial_voltages + expected_corrections, decimal=2
+            voltages, initial_voltages + expected_corrections, decimal=1
         )
 
 
@@ -144,6 +144,6 @@ def test_calculate_optimal_voltages_with_restrictions(
         )
 
         # assert correct voltages calculated
-        voltages = np.round(voltages, 2)
+        voltages = np.round(voltages, 1)
         mock_find_voltage_corrections_with_restraints.assert_called()
         assert check_voltages_fit_constraints(voltages, (-1000, 1000), 50)

--- a/tests/script_test.py
+++ b/tests/script_test.py
@@ -36,7 +36,7 @@ def test_find_voltages_correct_output(
     np.testing.assert_almost_equal(
         find_voltage_corrections(data, v, baseline_voltage_scan=-1),
         expected_corrections,
-        decimal=2,
+        decimal=1,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_outpath_option(outpath: str | bool):
             "bimorph_mirror_analysis.__main__.calculate_optimal_voltages"
         ) as mock_calculate_optimal_voltages,
     ):
-        mock_calculate_optimal_voltages.return_value = np.array([72.14, 50.98, 18.59])
+        mock_calculate_optimal_voltages.return_value = np.array([72.1, 51.0, 18.6])
         if type(outpath) is str:
             result = runner.invoke(
                 app,
@@ -60,7 +60,7 @@ def test_outpath_option(outpath: str | bool):
             baseline_voltage_scan=0,
             slit_range=None,
         )
-        assert "The optimal voltages are: [72.14, 50.98, 18.59]" in result.stdout
+        assert "The optimal voltages are: [72.1, 51.0, 18.6]" in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -83,7 +83,7 @@ def test_human_readable_option(human_readable: str | bool):
         # Create a mock DataFrame
         mock_pivoted = MagicMock(spec=pd.DataFrame)
         mock_read_bluesky_plan_output.return_value = (mock_pivoted,)
-        mock_calculate_optimal_voltages.return_value = np.array([72.14, 50.98, 18.59])
+        mock_calculate_optimal_voltages.return_value = np.array([72.1, 51.0, 18.6])
 
         if type(human_readable) is str:
             result = runner.invoke(
@@ -118,7 +118,7 @@ def test_human_readable_option(human_readable: str | bool):
             baseline_voltage_scan=0,
             slit_range=None,
         )
-        assert "The optimal voltages are: [72.14, 50.98, 18.59]" in result.stdout
+        assert "The optimal voltages are: [72.1, 51.0, 18.6]" in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -185,7 +185,7 @@ def test_slit_range_option(slit_range: str | bool, raw_data_pivoted: pd.DataFram
                 baseline_voltage_scan=0,
                 slit_range=None,
             )
-            assert "The optimal voltages are: [72.14, 50.98, 18.59]" in result.stdout
+            assert "The optimal voltages are: [72.1, 51.0, 18.6]" in result.stdout
         mock_np_save.assert_called_once()
 
 


### PR DESCRIPTION
fix checking if voltages fit restrictions, change rounding to 1 decimal places.

checking voltages fit restrictions now uses the absolute difference instead of relative outputted voltages are now 1 decimal place, necessary for the HV-ADAPTOS power supply tests have been updated for the 1 decimal place change